### PR TITLE
Re-Applied Material to Tube Worms

### DIFF
--- a/Assets/Prefabs/Corals/HydrothermicPrefabs/CoralTubeWorm.prefab
+++ b/Assets/Prefabs/Corals/HydrothermicPrefabs/CoralTubeWorm.prefab
@@ -47,7 +47,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a43fe3856bb158345a4ff83c30c4677b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  mat: {fileID: 2100000, guid: a8db78d0a2516de4c84c49c9ae53d6ba, type: 2}
+  mat: {fileID: 2100000, guid: ee4bcb4310e8c9e45b618a8a113e7293, type: 2}
   filter: {fileID: 1778713374299121268}
   meshrenderer: {fileID: 1778713374299121269}
   baseIterations: 14


### PR DESCRIPTION
+ in a merge the current wiggle texture was taken off of the worms, this commit puts that mat back on